### PR TITLE
Fixed lifetime stats for wakapi users + fix #82

### DIFF
--- a/app/src/main/java/com/gianlu/timeless/api/WakaTime.java
+++ b/app/src/main/java/com/gianlu/timeless/api/WakaTime.java
@@ -736,7 +736,7 @@ public class WakaTime {
             if (project != null)
                 builder.addQueryParameter("project", project);
 
-            return new LifetimeStats(doRequestSync(builder.build()));
+            return new LifetimeStats(doRequestSync(builder.build()), project);
         }
     }
 }

--- a/app/src/main/java/com/gianlu/timeless/api/models/LifetimeStats.java
+++ b/app/src/main/java/com/gianlu/timeless/api/models/LifetimeStats.java
@@ -12,11 +12,12 @@ public class LifetimeStats {
     public final String project;
     public final Long totalSeconds;
 
-    public LifetimeStats(@NonNull JSONObject obj) throws JSONException {
+    public LifetimeStats(@NonNull JSONObject obj, String projectName) throws JSONException {
         obj = obj.getJSONObject("data");
 
         upToDate = obj.getBoolean("is_up_to_date");
-        project = CommonUtils.optString(obj, "project");
+        String jsonProjectName = CommonUtils.optString(obj, "project");
+        project = jsonProjectName != null ? jsonProjectName : projectName;
         totalSeconds = CommonUtils.optLong(obj, "total_seconds");
     }
 }

--- a/app/src/main/java/com/gianlu/timeless/listing/BarChartViewHolder.java
+++ b/app/src/main/java/com/gianlu/timeless/listing/BarChartViewHolder.java
@@ -50,6 +50,7 @@ class BarChartViewHolder extends HelperViewHolder {
     private final TextView title;
     private final CombinedChart chart;
     private final ImageButton save;
+    private final MaterialColors materialColors;
 
     BarChartViewHolder(DialogUtils.ShowStuffInterface listener, LayoutInflater inflater, ViewGroup parent) {
         super(listener, inflater, parent, R.layout.item_chart_bar);
@@ -57,6 +58,7 @@ class BarChartViewHolder extends HelperViewHolder {
         title = itemView.findViewById(R.id.barChartCard_title);
         chart = itemView.findViewById(R.id.barChartCard_chart);
         save = itemView.findViewById(R.id.barChartCard_save);
+        materialColors = MaterialColors.getShuffledInstance();
     }
 
     @NotNull
@@ -116,7 +118,6 @@ class BarChartViewHolder extends HelperViewHolder {
         List<Integer> colors = new ArrayList<>();
         List<LegendEntry> legendEntries = new ArrayList<>();
         int colorCount = 0;
-        MaterialColors materialColors = MaterialColors.getShuffledInstance();
         for (int i = 0; i < summaries.size(); i++) {
             Summary summary = summaries.get(i);
             float[] array = new float[summary.projects.size()];

--- a/app/src/main/java/com/gianlu/timeless/listing/BarChartViewHolder.java
+++ b/app/src/main/java/com/gianlu/timeless/listing/BarChartViewHolder.java
@@ -1,5 +1,6 @@
 package com.gianlu.timeless.listing;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -50,7 +51,7 @@ class BarChartViewHolder extends HelperViewHolder {
     private final TextView title;
     private final CombinedChart chart;
     private final ImageButton save;
-    private final MaterialColors materialColors;
+    private static final MaterialColors materialColors = MaterialColors.getShuffledInstance();;
 
     BarChartViewHolder(DialogUtils.ShowStuffInterface listener, LayoutInflater inflater, ViewGroup parent) {
         super(listener, inflater, parent, R.layout.item_chart_bar);
@@ -58,7 +59,6 @@ class BarChartViewHolder extends HelperViewHolder {
         title = itemView.findViewById(R.id.barChartCard_title);
         chart = itemView.findViewById(R.id.barChartCard_chart);
         save = itemView.findViewById(R.id.barChartCard_save);
-        materialColors = MaterialColors.getShuffledInstance();
     }
 
     @NotNull

--- a/app/src/main/java/com/gianlu/timeless/listing/LineChartViewHolder.java
+++ b/app/src/main/java/com/gianlu/timeless/listing/LineChartViewHolder.java
@@ -40,6 +40,7 @@ class LineChartViewHolder extends HelperViewHolder {
     private final TextView title;
     private final LineChart chart;
     private final ImageButton save;
+    private static final MaterialColors materialColors = MaterialColors.getShuffledInstance();;
 
     LineChartViewHolder(DialogUtils.ShowStuffInterface listener, LayoutInflater inflater, ViewGroup parent) {
         super(listener, inflater, parent, R.layout.item_chart_line);
@@ -83,7 +84,6 @@ class LineChartViewHolder extends HelperViewHolder {
             }
         });
 
-        MaterialColors colors = MaterialColors.getShuffledInstance();
         Map<String, ILineDataSet> branchToSets = new HashMap<>(summaries.availableBranches.size());
         int maxEntries = 0;
         int i = 0;
@@ -91,7 +91,7 @@ class LineChartViewHolder extends HelperViewHolder {
             for (LoggedEntity branch : summary.branches) {
                 LineDataSet set = (LineDataSet) branchToSets.get(branch.name);
                 if (set == null) {
-                    int color = ContextCompat.getColor(getContext(), colors.getColor(i));
+                    int color = ContextCompat.getColor(getContext(), materialColors.getColor(i));
                     i++;
 
                     set = new LineDataSet(new ArrayList<>(), branch.name);


### PR DESCRIPTION
Wakapi's API is not entirely compatible with WakaTime. In particular, the `all_time_since_today` endpoint did not return the project name, which the `LifetimeStats` class required.

Therefore, I added a "fallback" project name, so that Wakatime users keep getting it from the backend, and Wakapi users can still use this feature.

--------------

I also kind of fixed issue #82. Colors are not persisted upon restart, that fix requires changes in the CommonUtils project and it didn't feel like a good idea*. I tried using the project name hash as an index for the color, but since the space is so small there were a lot of collisions and it didn't look great. I solved it by having a final `MaterialColors` instance, instead of shuffling it every bind.

*CommonUtils' `shuffleArray` uses `ThreadLocalRandom`, which is not seedable. To have seedable randomness I would have had to change quite a few things.